### PR TITLE
Implémente la phase 2 du plan

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('generate-btn');
+    btn.addEventListener('click', () => {
+        const textarea = document.getElementById('taxon-input');
+        const names = textarea.value.split(/\n+/).map(s => s.trim()).filter(Boolean);
+        fetch('/api/generer-tableau', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ scientific_names: names })
+        })
+            .then(resp => resp.json())
+            .then(data => displayResults(data))
+            .catch(err => {
+                console.error(err);
+                alert('Erreur lors de la récupération des données');
+            });
+    });
+
+});
+
+function displayResults(data) {
+    const container = document.getElementById('result-table');
+    container.innerHTML = '';
+    if (!Array.isArray(data)) {
+        container.textContent = 'Aucune donnée.';
+        return;
+    }
+    const table = document.createElement('table');
+    if (data.length === 0) {
+        container.textContent = 'Aucune espèce trouvée.';
+        return;
+    }
+    const headers = Object.keys(data[0]);
+    const thead = document.createElement('thead');
+    const trHead = document.createElement('tr');
+    headers.forEach(key => {
+        const th = document.createElement('th');
+        th.textContent = key;
+        trHead.appendChild(th);
+    });
+    thead.appendChild(trHead);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    data.forEach(row => {
+        const tr = document.createElement('tr');
+        headers.forEach(key => {
+            const td = document.createElement('td');
+            const val = row[key];
+            td.textContent = val === null || val === undefined ? '' : val;
+            if (key.toLowerCase().includes('liste_rouge')) {
+                if (val === 'LC') td.classList.add('status-lc');
+                if (val === 'EN') td.classList.add('status-en');
+                if (val === 'CR') td.classList.add('status-cr');
+            }
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>BDC Status TAXREF18</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>BDC Status TAXREF18</h1>
+    </header>
+    <main>
+        <textarea id="taxon-input" placeholder="Saisissez les noms latins, un par ligne"></textarea>
+        <button id="generate-btn">Générer</button>
+        <div id="result-table"></div>
+    </main>
+    <footer>
+        <p>Prototype utilisant l'API TAXREF</p>
+    </footer>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,55 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f9f9f9;
+}
+
+header, footer {
+    background-color: #2c3e50;
+    color: white;
+    text-align: center;
+    padding: 1rem;
+}
+
+main {
+    padding: 1rem;
+}
+
+textarea {
+    width: 100%;
+    height: 120px;
+}
+
+button {
+    margin-top: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+thead {
+    background-color: #34495e;
+    color: white;
+}
+
+td, th {
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+}
+
+.status-lc {
+    background-color: #abf7b1;
+}
+
+.status-en {
+    background-color: #fbe5a5;
+}
+
+.status-cr {
+    background-color: #f5a5a5;
+}


### PR DESCRIPTION
## Notes
- Création du dossier `frontend` avec trois fichiers :
  - `index.html` : structure de base de la page avec un champ de saisie et un bouton pour lancer la génération.
  - `style.css` : styles simples pour présenter la page et le tableau de résultats.
  - `app.js` : code JavaScript pour envoyer les noms d'espèces au backend et afficher le tableau de résultats.
- L'étape 1 (backend) était déjà opérationnelle. Cette PR réalise l'étape 2 du plan sans intégrer les fonctionnalités de phase 3.

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f40a83f4832ca71ab611249d4661